### PR TITLE
Updating parselib options

### DIFF
--- a/lib/dry.js
+++ b/lib/dry.js
@@ -21,7 +21,11 @@ module.exports = (function() {
         var sourceText = fs.readFileSync(source, 'utf8');
 
         // get a new parser
-        var parser = new parserlib.css.Parser();
+        var parser = new parserlib.css.Parser({
+            starHack: true,
+            underscoreHack: true,
+            ieFilters: true
+        });
 
         // set up the tree
         var ast = {};


### PR DESCRIPTION
By adding the following options to parselib, I've removed all the
errors by one from bootstrap.css:
- starHack: true
- underscoreHack: true
- ieFilters: true

The only error remaining is: Unknown @ rule: @-ms-keyframes
