### PR TITLE
Removing node 0.10 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - "0.10"
   - "0.8"
 before_script:
   - npm install -g grunt-cli


### PR DESCRIPTION
Removing option to build for node 0.10 for now. The npm install is failing when trying to build.
